### PR TITLE
Login result event functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ class SomeClass {
 
 ```haxe
 // This example show a simple use case.
-// This example show a simple use case.
 
 import extension.gpg.GooglePlayGames;
 
@@ -106,7 +105,7 @@ class MainClass {
 	function new() {
 		// first of all... call init on the main method passing the main stage as parameter.
 		// the second parameter is to enable cloud storage service.
-		// Set up the login result event callback first
+		// Set up the login result event callback first, always before init()
 		GooglePlayGames.onLoginResult = loginCallback;
 		GooglePlayGames.init(mainStage,true);
 	}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ OpenFL extension for "Google Play Games" on Android.
 * Login / Init.
 * Cloud Storage support (for storing progress / scores on google cloud - up to 4KB of data).
 * Callback events for onCloudComplete (read from cloud) and onCloudConflict (version conflict on cloud).
+* Callback event for login / init
 * Automatic conflict resolution (by keeping the newest version by default). You can change that by implementing the onCloudConflict method.
 * XML Parser to load the ID's from Google's XML resources file.
 
@@ -90,6 +91,44 @@ class SomeClass {
 	
 }
 
+```
+
+###Login event example
+
+```haxe
+// This example show a simple use case.
+// This example show a simple use case.
+
+import extension.gpg.GooglePlayGames;
+
+class MainClass {
+
+	function new() {
+		// first of all... call init on the main method passing the main stage as parameter.
+		// the second parameter is to enable cloud storage service.
+		// Set up the login result event callback first
+		GooglePlayGames.onLoginResult = loginCallback;
+		GooglePlayGames.init(mainStage,true);
+	}
+	
+	function login() {
+		// to force a login request to the user. This is optional and you may not even call this function
+		// at all. Call this just if you want to force the user to login (instead of waiting the user to
+		// call displayAchievements or displayScoreboard ...
+		GooglePlayGames.login();
+	}
+	
+	function loginCallback(result:Int):Void {
+		// The possible returned values are:
+		// -1 = failed login
+		//  0 = trying to log in
+		//  1 = logged in
+		// this event is fired several times on differents situations, results vary and must be tested
+		// and adapted to your game logic. for example, if you execute init() and login() but the user 				// doesn't login, cancel the operation, it will return: 0 -1 0 -1 , same as if the user is 			// not connected to the internet.
+		Lib.trace("Login result = "+result);
+	}
+	
+}
 ```
 
 ###XML Resources parsing example

--- a/dependencies/gpgex/src/com/gpgex/GameHelper.java
+++ b/dependencies/gpgex/src/com/gpgex/GameHelper.java
@@ -60,6 +60,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
 
         /** Called when sign-in succeeds. */
         void onSignInSucceeded();
+		
+		/** called when sign-in starts */
+		void onSignInStart();
+
     }
 
     // configuration done?
@@ -342,6 +346,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             } else {
                 debugLog("Connecting client.");
                 mConnecting = true;
+				mListener.onSignInStart();
                 mGoogleApiClient.connect();
             }
         } else {
@@ -576,6 +581,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
         }
 
         debugLog("Starting USER-INITIATED sign-in flow.");
+		mListener.onSignInStart();
 
         // indicate that user is actively trying to sign in (so we know to resolve
         // connection problems by showing dialogs)

--- a/dependencies/gpgex/src/com/gpgex/GooglePlayGames.java
+++ b/dependencies/gpgex/src/com/gpgex/GooglePlayGames.java
@@ -22,6 +22,7 @@ public class GooglePlayGames extends Extension implements GameHelper.GameHelperL
 	public static final String TAG = "OPENFL-GPG";
 	private static boolean userRequiresLogin=false;
 	private static HaxeObject onDataGetObject=null;
+	private static HaxeObject onDataLoginResult=null;
 	private static boolean enableCloudStorage=false;
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -115,13 +116,22 @@ public class GooglePlayGames extends Extension implements GameHelper.GameHelperL
 
 	@Override
     public void onSignInFailed() {
+		if(onDataLoginResult!=null) onDataLoginResult.call1("loginResultCallback",-1);
         Log.i(TAG, "PlayGames: onSignInFailed");
     }
 
     @Override
     public void onSignInSucceeded() {
+		if(onDataLoginResult!=null) onDataLoginResult.call1("loginResultCallback",1);
         Log.i(TAG, "PlayGames: onSignInSucceeded");
     }
+	
+	@Override
+    public void onSignInStart() {
+		if(onDataLoginResult!=null) onDataLoginResult.call1("loginResultCallback",0);
+        Log.i(TAG, "PlayGames: onSignInStart");
+    }
+	
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -244,4 +254,12 @@ public class GooglePlayGames extends Extension implements GameHelper.GameHelperL
 		}
 		return true;
 	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////////////
+	
+	public static boolean setLoginResultCallback(HaxeObject callbackObject){
+		onDataLoginResult = callbackObject;
+		return true;
+	}		
 }


### PR DESCRIPTION
Hi,

the lib is awesome and works out of the box, but the crappy google play services require on most of the cases, of this function to avoid glitches and bugs on the game play. for example, in my case (and like nitrome games does), i have a loading screen i show in the meantime i set up everything ( game data, ads if exist, and leaderboards) and i force the login of the user in that phase. for this reason, i need to know when google play services finished to use the activity, to load the game world. with this function, i was able to detect a pattern of results depending different circumstances, if the connection is up, if the user logged in or not etc.. to know when to load the actual game. is enough flexible and useful to be adapted to any kind of game logic.

i tried to follow your code structure as much i could, and added instructions to the readme. if you could merge it and release a new haxelib package with it, it would be awesome :D

Regards.